### PR TITLE
Remove comments in json

### DIFF
--- a/botsettings.example.json
+++ b/botsettings.example.json
@@ -3,6 +3,6 @@
     "prefix": "YOUR_DISCORD_BOT_PREFIX",
     "dev1": "YOUR_DISCORD_ID",
     "logs": "A_LOG_CHANNEL",
-    "checkemoji": "CHECK_MARK_EMOJI", // https://cdn.discordapp.com/emojis/798519537565696000.gif?v=1
-    "wrongemoji": "WRONG_EMOJI" // https://cdn.discordapp.com/emojis/798518925608222779.gif?v=1
+    "checkemoji": "CHECK_MARK_EMOJI", 
+    "wrongemoji": "WRONG_EMOJI" 
 }


### PR DESCRIPTION
The comment gives an error.
As `//` isn't used in JSON files.